### PR TITLE
Quick fix to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "react-scripts --openssl-legacy-provider start",
-    "build": "react-scripts build",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "precommit": "pretty-quick --staged"


### PR DESCRIPTION
Build method wasn't working because it didn't have the openssl legacy fix. This page is meant to be built as a static page so it shouldn't necessarily apply and be of a concern.